### PR TITLE
Add support for `Logger#silence`.

### DIFF
--- a/lib/console/adapter/rails.rb
+++ b/lib/console/adapter/rails.rb
@@ -4,7 +4,6 @@
 # Copyright, 2023, by Samuel Williams.
 
 require 'console'
-require 'console/compatible/logger'
 
 require 'active_support/log_subscriber'
 require 'active_support/tagged_logging'
@@ -12,6 +11,7 @@ require 'action_controller/log_subscriber'
 require 'action_view/log_subscriber'
 require 'active_job/log_subscriber'
 
+require_relative 'rails/logger'
 require_relative 'rails/active_support'
 
 module Console
@@ -75,13 +75,7 @@ module Console
 				end
 				
 				if configuration
-					# Set the logger to a compatible logger to catch `Rails.logger` output:
-					configuration.logger = ActiveSupport::TaggedLogging.new(
-						Console::Compatible::Logger.new(::Rails)
-					)
-					
-					# Delete `Rails::Rack::Logger` as it also doubles up on request logs:
-					configuration.middleware.delete ::Rails::Rack::Logger
+					Logger.apply!(configuration: configuration)
 				end
 				
 				# Attach our log subscriber for action_controller events:

--- a/lib/console/adapter/rails/logger.rb
+++ b/lib/console/adapter/rails/logger.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Samuel Williams.
+
+require 'console/compatible/logger'
+
+module Console
+	module Adapter
+		# A Rails adapter for the console logger.
+		module Rails
+			class Logger < ::Console::Compatible::Logger
+				include ::ActiveSupport::LoggerSilence
+				
+				def self.apply!(configuration: ::Rails.configuration)
+					# Set the logger to a compatible logger to catch `Rails.logger` output:
+					configuration.logger = ActiveSupport::TaggedLogging.new(
+						Logger.new(::Rails)
+					)
+					
+					# Delete `Rails::Rack::Logger` as it also doubles up on request logs:
+					configuration.middleware.delete ::Rails::Rack::Logger
+				end
+			end
+		end
+	end
+end

--- a/test/console/adapter/rails.rb
+++ b/test/console/adapter/rails.rb
@@ -21,6 +21,10 @@ describe Rails do
 		expect(Rails.logger).to be(:respond_to?, :tagged)
 	end
 	
+	it "should support silence" do
+		expect(Rails.logger).to be(:respond_to?, :silence)
+	end
+	
 	it "does not output to stdout" do
 		skip_unless_method_defined(:logger_outputs_to?, ActiveSupport::Logger.singleton_class)
 		


### PR DESCRIPTION
In older versions of Rails, there is code in `sprockets` which unconditionally invokes this method.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
