### PR TITLE
Replace "silence" implementation with one that doesn't bork logging.

### DIFF
--- a/console-adapter-rails.gemspec
+++ b/console-adapter-rails.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.21"
 	spec.add_dependency "rails", ">= 6.1"
+	spec.add_dependency "fiber-storage", "~> 0.1"
 end

--- a/test/console/adapter/rails/logger.rb
+++ b/test/console/adapter/rails/logger.rb
@@ -22,6 +22,12 @@ describe Console::Adapter::Rails::Logger do
 	
 	it "should support silence" do
 		expect(Rails.logger).to be(:respond_to?, :silence)
+		
+		Rails.logger.silence(Logger::ERROR) do
+			Rails.logger.info("Hello World")
+		end
+		
+		expect(capture.last).to be_nil
 	end
 	
 	it "does not output to stdout" do
@@ -30,5 +36,15 @@ describe Console::Adapter::Rails::Logger do
 		expect(
 			ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDOUT)
 		).to be == true
+	end
+	
+	it "can log a message" do
+		Rails.logger.info("Hello World")
+		
+		expect(capture.last).to have_keys(
+			severity: be == :info,
+			subject: be == Rails,
+			arguments: be == ["Hello World"]
+		)
 	end
 end


### PR DESCRIPTION
The implementation of `::ActiveSupport::LoggerSilence` overwrites the `Logger#add` in an incompatible way. So we need to make our own implementation.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
