### PR TITLE
Rewrite using Railtie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /pkg/
 /gems.locked
+/gems/*.lock
 /.covered.db
 /external
 
@@ -9,3 +10,4 @@
 
 /gems.locked
 /fixtures/test.db
+/fixtures/log/

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 
 /gems.locked
 /fixtures/test.db
-/fixtures/log/

--- a/fixtures/app.rb
+++ b/fixtures/app.rb
@@ -23,8 +23,6 @@ class TestApplication < Rails::Application
 	end
 end
 
-Console::Adapter::Rails.apply!
-
 module TestHelper
 end
 

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -7,23 +7,9 @@ This guide explains how to integrate the `console-adapter-rails` gem into your R
 Add the gem to your project:
 
 ~~~ bash
-$ bundle add console
+$ bundle add console-adapter-rails
 ~~~
 
-## Update your Environment
+The gem includes a Railtie that will set up all required logging configuration for you.
 
-To add this to a Rails application, update your `config/environment.rb` file:
-
-~~~ ruby
-# frozen_string_literal: true
-
-# Load the Rails application.
-require_relative 'application'
-
-# Setup the console adapter:
-require 'console/adapter/rails'
-Console::Adapter::Rails.apply!
-
-# Initialize the Rails application.
-Rails.application.initialize!
-~~~
+If you wish to log ActiveRecord, add `Console::Adapter::Rails::ActiveRecord.apply!` into your `config/environment.rb` file, before the `Rails.application.initialize!` call.

--- a/lib/console/adapter/rails.rb
+++ b/lib/console/adapter/rails.rb
@@ -6,27 +6,14 @@
 require_relative 'rails/logger'
 require_relative 'rails/action_controller'
 require_relative 'rails/active_record'
+require_relative 'rails/railtie'
 
 module Console
 	module Adapter
 		# A Rails adapter for the console logger.
 		module Rails
-			# Apply the Rails adapter to the current process and Rails application.
-			# @parameter notifications [ActiveSupport::Notifications] The notifications object to use.
-			# @parameter configuration [Rails::Configuration] The configuration object to use.
-			def self.apply!(notifications: ActiveSupport::Notifications, configuration: ::Rails.configuration)
-				if configuration
-					Logger.apply!(configuration: configuration)
-				end
-				
-				if notifications
-					# Clear out all the existing subscribers otherwise you'll get double the logs:
-					notifications.notifier = ActiveSupport::Notifications::Fanout.new
-					
-					# Add our own subscribers:
-					Rails::ActionController.apply!(notifications: notifications)
-					# Rails::ActiveRecord.apply!(notifications: notifications)
-				end
+			# Placeholder to remain compatible with older clients
+			def self.apply!
 			end
 		end
 	end

--- a/lib/console/adapter/rails/logger.rb
+++ b/lib/console/adapter/rails/logger.rb
@@ -59,14 +59,11 @@ module Console
 					super(severity, message, progname, &block)
 				end
 				
-				def self.apply!(configuration: ::Rails.configuration)
+				def self.apply!(rails: ::Rails)
 					# Set the logger to a compatible logger to catch `Rails.logger` output:
-					configuration.logger = ActiveSupport::TaggedLogging.new(
+					rails.logger = ActiveSupport::TaggedLogging.new(
 						Logger.new(::Rails)
 					)
-					
-					# Delete `Rails::Rack::Logger` as it also doubles up on request logs:
-					configuration.middleware.delete ::Rails::Rack::Logger
 				end
 			end
 		end

--- a/lib/console/adapter/rails/logger.rb
+++ b/lib/console/adapter/rails/logger.rb
@@ -59,9 +59,9 @@ module Console
 					super(severity, message, progname, &block)
 				end
 				
-				def self.apply!(rails: ::Rails)
+				def self.apply!(configuration: ::Rails.configuration)
 					# Set the logger to a compatible logger to catch `Rails.logger` output:
-					rails.logger = ActiveSupport::TaggedLogging.new(
+					configuration.logger = ActiveSupport::TaggedLogging.new(
 						Logger.new(::Rails)
 					)
 				end

--- a/lib/console/adapter/rails/railtie.rb
+++ b/lib/console/adapter/rails/railtie.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Samuel Williams.
+
+require 'action_controller/log_subscriber'
+require 'action_view/log_subscriber'
+
+module Console
+	module Adapter
+		module Rails
+			# Hook into Rails startup process and replace Rails.logger with our custom hooks
+      class Railtie < ::Rails::Railtie
+				initializer 'console.adapter.rails' do |app|
+					# 1. Set up Console to be used as the Rails logger
+					Logger.apply!
+
+					# 2. Remove the Rails::Rack::Logger middleware as it also doubles up on request logs
+					app.middleware.delete ::Rails::Rack::Logger
+				end
+
+				# 3. Remove existing log subscribers for ActionController and ActionView
+        config.after_initialize do
+					::ActionController::LogSubscriber.detach_from :action_controller
+
+					# Silence the default action view logs, e.g. "Rendering text template" etc
+					::ActionView::LogSubscriber.detach_from :action_view
+				end
+
+        config.after_initialize do
+					# 4. Add a new log subscriber for ActionController
+					ActionController.apply!
+
+					# 5. (optionally) Add a new log subscriber for ActiveRecord
+					# ActiveRecord.apply!
+        end
+      end
+    end
+  end
+end

--- a/lib/console/adapter/rails/railtie.rb
+++ b/lib/console/adapter/rails/railtie.rb
@@ -11,9 +11,9 @@ module Console
 		module Rails
 			# Hook into Rails startup process and replace Rails.logger with our custom hooks
       class Railtie < ::Rails::Railtie
-				initializer 'console.adapter.rails' do |app|
+				initializer 'console.adapter.rails', before: :initialize_logger do |app|
 					# 1. Set up Console to be used as the Rails logger
-					Logger.apply!
+					Logger.apply!(configuration: app.config)
 
 					# 2. Remove the Rails::Rack::Logger middleware as it also doubles up on request logs
 					app.middleware.delete ::Rails::Rack::Logger

--- a/test/console/adapter/rails/active_record.rb
+++ b/test/console/adapter/rails/active_record.rb
@@ -7,7 +7,7 @@ require 'app'
 require 'console/capture'
 require 'console/logger'
 
-describe Console::Adapter::Rails::ActionController do
+describe Console::Adapter::Rails::ActiveRecord do
 	let(:capture) {Console::Capture.new}
 	let(:logger) {Console::Logger.new(capture)}
 	
@@ -15,6 +15,7 @@ describe Console::Adapter::Rails::ActionController do
 		super
 		
 		Console.logger = logger
+		Console::Adapter::Rails::ActiveRecord.apply!
 	end
 	
 	it "can generate query logs when creating record" do

--- a/test/console/adapter/rails/logger.rb
+++ b/test/console/adapter/rails/logger.rb
@@ -10,6 +10,7 @@ require 'console/logger'
 describe Console::Adapter::Rails::Logger do
 	let(:capture) {Console::Capture.new}
 	let(:logger) {Console::Logger.new(capture)}
+	let(:instance) {subject.new(::Rails)}
 	
 	def before
 		super
@@ -46,5 +47,22 @@ describe Console::Adapter::Rails::Logger do
 			subject: be == Rails,
 			arguments: be == ["Hello World"]
 		)
+	end
+
+	it "behaves like Rails 6 logger" do
+		instance.silence(Logger::ERROR) do
+			instance.info("Hello World")
+		end
+
+		expect(capture.last).to be_nil
+	end
+
+	it "behaves like Rails 7 logger" do
+		instance.local_level = Logger::ERROR
+		expect(instance.local_level).to be == Logger::ERROR
+		instance.info("Hello World")
+		instance.local_level = nil
+
+		expect(capture.last).to be_nil
 	end
 end


### PR DESCRIPTION
Set up logging configuration using a Railtie so that it is not dependent on load order of gems.

Also silences some output from ActionView when rendering views.

Tested locally with:
* A very large Rails 6.1 application.
* An old/poorly maintained Rails 6.1 application.
* An actively maintained Rails 7 application.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
