### PR TITLE
Build and pass tags as options to logger

### DIFF
--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -17,9 +17,9 @@ jobs:
           - macos
         
         ruby:
-          - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
     
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,9 +18,9 @@ jobs:
           - macos
         
         ruby:
-          - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
         
         experimental: [false]
         

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Yasha Krasnou <yakau.krasnou@44pixels.ai>

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,25 @@ Layout/SpaceAroundBlockParameters:
   Enabled: true
   EnforcedStyleInsidePipes: no_space
 
+Layout/FirstArrayElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/ArrayAlignment:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+
+Layout/FirstArgumentIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/ArgumentAlignment:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   Enabled: true
 

--- a/bake.rb
+++ b/bake.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2025, by Samuel Williams.
+# Copyright, 2025-2026, by Samuel Williams.
 
 # Update the project documentation with the new version number.
 #
@@ -9,4 +9,11 @@
 def after_gem_release_version_increment(version)
 	context["releases:update"].call(version)
 	context["utopia:project:update"].call
+end
+
+# Create a GitHub release for the given tag.
+#
+# @parameter tag [String] The tag to create a release for.
+def after_gem_release(tag:, **options)
+	context["releases:github:release"].call(tag)
 end

--- a/config/sus.rb
+++ b/config/sus.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 
 require "covered/sus"
 include Covered::Sus

--- a/console-adapter-rails.gemspec
+++ b/console-adapter-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 	
 	spec.files = Dir.glob(["{context,lib}/**/*", "*.md"], File::FNM_DOTMATCH, base: __dir__)
 	
-	spec.required_ruby_version = ">= 3.2"
+	spec.required_ruby_version = ">= 3.3"
 	
 	spec.add_dependency "console", "~> 1.21"
 	spec.add_dependency "fiber-storage", "~> 1.0"

--- a/console-adapter-rails.gemspec
+++ b/console-adapter-rails.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
 	spec.version = Console::Adapter::Rails::VERSION
 	
 	spec.summary = "Adapt Rails logs and events to the console gem."
-	spec.authors = ["Samuel Williams", "Joshua Young", "Jun Jiang", "Michael Adams"]
+	spec.authors = ["Samuel Williams", "Joshua Young", "Jun Jiang", "Michael Adams", "Yasha Krasnou"]
 	spec.license = "MIT"
 	
 	spec.cert_chain  = ["release.cert"]
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.3"
 	
-	spec.add_dependency "console", "~> 1.21"
+	spec.add_dependency "console", "~> 1.34"
 	spec.add_dependency "fiber-storage", "~> 1.0"
 	spec.add_dependency "rails", ">= 7.0"
 end

--- a/fixtures/app.rb
+++ b/fixtures/app.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2024, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 # Copyright, 2024, by Michael Adams.
 
 require "rails"

--- a/gems/rails-v7.rb
+++ b/gems/rails-v7.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2024, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 
 eval_gemfile("../gems.rb")
 

--- a/gems/rails-v8.rb
+++ b/gems/rails-v8.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2024, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 # Copyright, 2025, by Jun Jiang.
 
 eval_gemfile("../gems.rb")

--- a/lib/console/adapter/rails.rb
+++ b/lib/console/adapter/rails.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2024, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 # Copyright, 2024, by Michael Adams.
 
 require_relative "rails/logger"

--- a/lib/console/adapter/rails/logger.rb
+++ b/lib/console/adapter/rails/logger.rb
@@ -3,6 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2023-2025, by Samuel Williams.
 # Copyright, 2024, by Michael Adams.
+# Copyright, 2026, by Yasha Krasnou.
 
 require "console/compatible/logger"
 
@@ -83,7 +84,25 @@ module Console
 				def add(severity, message = nil, progname = nil, &block)
 					return if silenced?(severity)
 					
-					super(severity, message, progname, &block)
+					if formatter.respond_to?(:tag_stack)
+						tags = formatter.tag_stack.tags
+						
+						options = tags.each_with_object({}) do |tag, memo|
+							next unless tag.respond_to?(:to_hash)
+							
+							tag.to_hash.each do |key, value|
+								case key
+								when Symbol
+									memo[key] = value
+								else
+									next unless key.respond_to?(:to_sym)
+									memo[key.to_sym] = value
+								end
+							end
+						end
+					end
+					
+					super(severity, message, progname, **options, &block)
 				end
 				
 				# Configure Rails to use the Console logger.

--- a/lib/console/adapter/rails/railtie.rb
+++ b/lib/console/adapter/rails/railtie.rb
@@ -2,7 +2,7 @@
 
 # Released under the MIT License.
 # Copyright, 2024, by Michael Adams.
-# Copyright, 2024, by Samuel Williams.
+# Copyright, 2024-2026, by Samuel Williams.
 # Copyright, 2025, by Jun Jiang.
 
 require "action_controller/log_subscriber"

--- a/license.md
+++ b/license.md
@@ -4,6 +4,7 @@ Copyright, 2023-2026, by Samuel Williams.
 Copyright, 2023, by Joshua Young.  
 Copyright, 2024, by Michael Adams.  
 Copyright, 2025, by Jun Jiang.  
+Copyright, 2026, by Yasha Krasnou.  
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright, 2023-2025, by Samuel Williams.  
+Copyright, 2023-2026, by Samuel Williams.  
 Copyright, 2023, by Joshua Young.  
 Copyright, 2024, by Michael Adams.  
 Copyright, 2025, by Jun Jiang.  

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,22 @@ We welcome contributions to this project.
 4.  Push to the branch (`git push origin my-new-feature`).
 5.  Create new Pull Request.
 
+### Running Tests
+
+To run the test suite:
+
+``` shell
+bundle exec sus
+```
+
+### Making Releases
+
+To make a new release:
+
+``` shell
+bundle exec bake gem:release:patch # or minor or major
+```
+
 ### Developer Certificate of Origin
 
 In order to protect users of this project, we require all contributors to comply with the [Developer Certificate of Origin](https://developercertificate.org/). This ensures that all contributions are properly licensed and attributed.

--- a/test/console/adapter/rails/action_controller.rb
+++ b/test/console/adapter/rails/action_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 
 require "app"
 require "console/capture"

--- a/test/console/adapter/rails/active_record.rb
+++ b/test/console/adapter/rails/active_record.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2024, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 # Copyright, 2024, by Michael Adams.
 
 require "app"

--- a/test/console/adapter/rails/logger.rb
+++ b/test/console/adapter/rails/logger.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2023-2024, by Samuel Williams.
+# Copyright, 2023-2026, by Samuel Williams.
 # Copyright, 2024, by Michael Adams.
 
 require "app"

--- a/test/console/adapter/rails/logger.rb
+++ b/test/console/adapter/rails/logger.rb
@@ -3,6 +3,7 @@
 # Released under the MIT License.
 # Copyright, 2023-2026, by Samuel Williams.
 # Copyright, 2024, by Michael Adams.
+# Copyright, 2026, by Yasha Krasnou.
 
 require "app"
 require "console/capture"
@@ -19,6 +20,54 @@ describe Console::Adapter::Rails::Logger do
 		
 		it "should support tags" do
 			expect(Rails.logger).to be(:respond_to?, :tagged)
+		end
+		
+		it "should log tags that are Hashes" do
+			Rails.logger.tagged({ foo: "bar" }) do
+				Rails.logger.info("Hello World")
+			end
+			
+			expect(capture.last).to have_keys(
+				message: be == "Hello World",
+				foo: be == "bar"
+			)
+		end
+		
+		it "should not fail when logging string tags" do
+			Rails.logger.tagged("foo=bar") do
+				Rails.logger.info("Hello World")
+			end
+			
+			expect(capture.last).to have_keys(
+				message: be == "Hello World"
+			)
+			
+			expect(capture.last).not.to have_keys(:foo)
+			expect(capture.last).not.to have_keys("foo=bar")
+		end
+		
+		it "should symbolize string-keyed hash tags" do
+			Rails.logger.tagged({ "request_id" => "abc" }) do
+				Rails.logger.info("Hello World")
+			end
+			
+			expect(capture.last).to have_keys(
+				message: be == "Hello World",
+				request_id: be == "abc"
+			)
+			expect(capture.last).not.to have_keys("request_id")
+		end
+		
+		it "should symbolize HashWithIndifferentAccess tags" do
+			Rails.logger.tagged(ActiveSupport::HashWithIndifferentAccess.new(request_id: "xyz")) do
+				Rails.logger.info("Hello World")
+			end
+			
+			expect(capture.last).to have_keys(
+				message: be == "Hello World",
+				request_id: be == "xyz"
+			)
+			expect(capture.last).not.to have_keys("request_id")
 		end
 		
 		it "should support silence" do


### PR DESCRIPTION
[Issue](https://github.com/socketry/console-adapter-rails/issues/14)
This is one of 2 changes needed to support the use of `Rails.logger.tagged` ([another part](https://github.com/socketry/console/pull/79))

This only works with hash type tags, e.g. `Rails.logger.tagged({ request_id: 137 })`

## Types of Changes

- New feature.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
