### PR TITLE
Update railtie.rb

### DIFF
--- a/.github/workflows/documentation-coverage.yaml
+++ b/.github/workflows/documentation-coverage.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.3"

--- a/.github/workflows/documentation-coverage.yaml
+++ b/.github/workflows/documentation-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.3"
+        ruby-version: "3.4"
         bundler-cache: true
     
     - name: Validate coverage

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.3"
+        ruby-version: "3.4"
         bundler-cache: true
     
     - name: Installing packages

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: ruby/setup-ruby@v1
       with:
@@ -40,7 +40,7 @@ jobs:
       run: bundle exec bake utopia:project:static --force no
     
     - name: Upload documentation artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: docs
   

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,7 @@ jobs:
           - "3.3"
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
@@ -34,7 +34,7 @@ jobs:
       timeout-minutes: 5
       run: bundle exec bake test
     
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v5
       with:
         name: coverage-${{matrix.os}}-${{matrix.ruby}}
         path: .covered.db
@@ -44,13 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.3"
         bundler-cache: true
     
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v5
     
     - name: Validate coverage
       timeout-minutes: 5

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -22,6 +22,7 @@ jobs:
         
         ruby:
           - "3.3"
+          - "3.4"
     
     steps:
     - uses: actions/checkout@v6
@@ -47,7 +48,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.3"
+        ruby-version: "3.4"
         bundler-cache: true
     
     - uses: actions/download-artifact@v5

--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -20,9 +20,7 @@ jobs:
           - macos
         
         ruby:
-          - "3.1"
-          - "3.2"
-          - "3.3"
+          - "3.4"
     
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -25,7 +25,7 @@ jobs:
           - "3.3"
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,13 +21,12 @@ jobs:
           - macos
         
         ruby:
-          - "3.1"
-          - "3.2"
           - "3.3"
+          - "3.4"
         
         gemfile:
-          - gems/rails-v6.rb
           - gems/rails-v7.rb
+          - gems/rails-v8.rb
           
         experimental: [false]
         

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       BUNDLE_GEMFILE: ${{matrix.gemfile}}
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}

--- a/console-adapter-rails.gemspec
+++ b/console-adapter-rails.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.21"
 	spec.add_dependency "fiber-storage", "~> 1.0"
-	spec.add_dependency "rails", ">= 6.1"
+	spec.add_dependency "rails", ">= 7.0"
 end

--- a/gems.rb
+++ b/gems.rb
@@ -23,5 +23,5 @@ group :test do
 	gem "bake-test"
 	gem "bake-test-external"
 	
-	gem "sqlite3", "~> 1.4"
+	gem "sqlite3", ">= 1.4"
 end

--- a/gems/rails-v8.rb
+++ b/gems/rails-v8.rb
@@ -5,4 +5,4 @@
 
 eval_gemfile('../gems.rb')
 
-gem 'rails', '~> 6.0'
+gem 'rails', '~> 8.0'

--- a/lib/console/adapter/rails/railtie.rb
+++ b/lib/console/adapter/rails/railtie.rb
@@ -13,36 +13,36 @@ module Console
 			# Hook into Rails startup process and replace Rails.logger with our custom hooks
 			class Railtie < ::Rails::Railtie
 				initializer 'console.adapter.rails', before: :initialize_logger do |app|
-									# 1. Set up Console to be used as the Rails logger
-									Logger.apply!(configuration: app.config)
-
-									# 2. Remove the Rails::Rack::Logger middleware as it also doubles up on request logs
-									app.middleware.delete ::Rails::Rack::Logger
-								end
-
+					# 1. Set up Console to be used as the Rails logger
+					Logger.apply!(configuration: app.config)
+					
+					# 2. Remove the Rails::Rack::Logger middleware as it also doubles up on request logs
+					app.middleware.delete ::Rails::Rack::Logger
+				end
+				
 				# 3. Remove existing log subscribers for ActionController and ActionView
 				config.after_initialize do
-									if ::ActionController::LogSubscriber < ::ActiveSupport::LogSubscriber
-										::ActionController::LogSubscriber.detach_from :action_controller
-									else
-										::ActiveSupport.event_reporter.unsubscribe(::ActionController::LogSubscriber)
-									end
-
-									# Silence the default action view logs, e.g. "Rendering text template" etc
-									if ::ActionView::LogSubscriber < ::ActiveSupport::LogSubscriber
-										::ActionView::LogSubscriber.detach_from :action_view
-									else
-										::ActiveSupport.event_reporter.unsubscribe(::ActionView::LogSubscriber)
-									end
-								end
-
+					if ::ActionController::LogSubscriber < ::ActiveSupport::LogSubscriber
+						::ActionController::LogSubscriber.detach_from :action_controller
+					else
+						::ActiveSupport.event_reporter.unsubscribe(::ActionController::LogSubscriber)
+					end
+					
+					# Silence the default action view logs, e.g. "Rendering text template" etc
+					if ::ActionView::LogSubscriber < ::ActiveSupport::LogSubscriber
+						::ActionView::LogSubscriber.detach_from :action_view
+					else
+						::ActiveSupport.event_reporter.unsubscribe(::ActionView::LogSubscriber)
+					end
+				end
+				
 				config.after_initialize do
-									# 4. Add a new log subscriber for ActionController
-									ActionController.apply!
-
-									# 5. (optionally) Add a new log subscriber for ActiveRecord
-									# ActiveRecord.apply!
-								end
+					# 4. Add a new log subscriber for ActionController
+					ActionController.apply!
+					
+					# 5. (optionally) Add a new log subscriber for ActiveRecord
+					# ActiveRecord.apply!
+				end
 			end
 		end
 	end

--- a/lib/console/adapter/rails/railtie.rb
+++ b/lib/console/adapter/rails/railtie.rb
@@ -13,28 +13,36 @@ module Console
 			# Hook into Rails startup process and replace Rails.logger with our custom hooks
 			class Railtie < ::Rails::Railtie
 				initializer 'console.adapter.rails', before: :initialize_logger do |app|
-					# 1. Set up Console to be used as the Rails logger
-					Logger.apply!(configuration: app.config)
+									# 1. Set up Console to be used as the Rails logger
+									Logger.apply!(configuration: app.config)
 
-					# 2. Remove the Rails::Rack::Logger middleware as it also doubles up on request logs
-					app.middleware.delete ::Rails::Rack::Logger
-				end
+									# 2. Remove the Rails::Rack::Logger middleware as it also doubles up on request logs
+									app.middleware.delete ::Rails::Rack::Logger
+								end
 
 				# 3. Remove existing log subscribers for ActionController and ActionView
 				config.after_initialize do
-					::ActionController::LogSubscriber.detach_from :action_controller
+									if ::ActionController::LogSubscriber < ::ActiveSupport::LogSubscriber
+										::ActionController::LogSubscriber.detach_from :action_controller
+									else
+										::ActiveSupport.event_reporter.unsubscribe(::ActionController::LogSubscriber)
+									end
 
-					# Silence the default action view logs, e.g. "Rendering text template" etc
-					::ActionView::LogSubscriber.detach_from :action_view
-				end
+									# Silence the default action view logs, e.g. "Rendering text template" etc
+									if ::ActionView::LogSubscriber < ::ActiveSupport::LogSubscriber
+										::ActionView::LogSubscriber.detach_from :action_view
+									else
+										::ActiveSupport.event_reporter.unsubscribe(::ActionView::LogSubscriber)
+									end
+								end
 
 				config.after_initialize do
-					# 4. Add a new log subscriber for ActionController
-					ActionController.apply!
+									# 4. Add a new log subscriber for ActionController
+									ActionController.apply!
 
-					# 5. (optionally) Add a new log subscriber for ActiveRecord
-					# ActiveRecord.apply!
-				end
+									# 5. (optionally) Add a new log subscriber for ActiveRecord
+									# ActiveRecord.apply!
+								end
 			end
 		end
 	end


### PR DESCRIPTION
## Types of Changes

I'm using the latest main branch of Rails and integrating Falcon.

When I start the server, I got error

```
$ rails s
=> Booting Falcon v0.52.4
=> Rails 8.2.0.alpha application starting in development http://localhost:3000
=> Run `bin/rails server --help` for more startup options
Exiting
/Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/console-adapter-rails-0.4.1/lib/console/adapter/rails/railtie.rb:25:in 'block in <class:Railtie>': undefined method 'detach_from' for class ActionController::LogSubscriber (NoMethodError)

					::ActionController::LogSubscriber.detach_from :action_controller
					                                 ^^^^^^^^^^^^
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/activesupport/lib/active_support/lazy_load_hooks.rb:94:in 'block in ActiveSupport::LazyLoadHooks#execute_hook'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/activesupport/lib/active_support/lazy_load_hooks.rb:87:in 'ActiveSupport::LazyLoadHooks#with_execution_control'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/activesupport/lib/active_support/lazy_load_hooks.rb:92:in 'ActiveSupport::LazyLoadHooks#execute_hook'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/activesupport/lib/active_support/lazy_load_hooks.rb:78:in 'block in ActiveSupport::LazyLoadHooks#run_load_hooks'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/activesupport/lib/active_support/lazy_load_hooks.rb:77:in 'Array#each'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/activesupport/lib/active_support/lazy_load_hooks.rb:77:in 'ActiveSupport::LazyLoadHooks#run_load_hooks'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/application/finisher.rb:93:in 'block in <module:Finisher>'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/initializable.rb:24:in 'BasicObject#instance_exec'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/initializable.rb:24:in 'Rails::Initializable::Initializer#run'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/initializable.rb:103:in 'block in Rails::Initializable#run_initializers'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:231:in 'block in TSort.tsort_each'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:353:in 'block (2 levels) in TSort.each_strongly_connected_component'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:434:in 'TSort.each_strongly_connected_component_from'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:352:in 'block in TSort.each_strongly_connected_component'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/initializable.rb:59:in 'Array#each'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/initializable.rb:59:in 'Rails::Initializable::Collection#each'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:350:in 'Method#call'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:350:in 'TSort.each_strongly_connected_component'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:229:in 'TSort.tsort_each'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/tsort-0.2.0/lib/tsort.rb:208:in 'TSort#tsort_each'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/initializable.rb:102:in 'Rails::Initializable#run_initializers'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/application.rb:442:in 'Rails::Application#initialize!'
	from /Users/jasl/Workspaces/vibe_the_world/config/environment.rb:5:in '<main>'
	from config.ru:3:in 'Kernel#require_relative'
	from config.ru:3:in 'block (2 levels) in <main>'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rack-3.2.4/lib/rack/builder.rb:108:in 'Kernel#eval'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rack-3.2.4/lib/rack/builder.rb:108:in 'Rack::Builder.new_from_string'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rack-3.2.4/lib/rack/builder.rb:97:in 'Rack::Builder.load_file'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rack-3.2.4/lib/rack/builder.rb:67:in 'Rack::Builder.parse_file'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rackup-2.3.1/lib/rackup/server.rb:354:in 'Rackup::Server#build_app_and_options_from_config'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rackup-2.3.1/lib/rackup/server.rb:263:in 'Rackup::Server#app'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rackup-2.3.1/lib/rackup/server.rb:424:in 'Rackup::Server#wrapped_app'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/commands/server/server_command.rb:76:in 'Rails::Server#log_to_stdout'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/commands/server/server_command.rb:36:in 'Rails::Server#start'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/commands/server/server_command.rb:145:in 'block in Rails::Command::ServerCommand#perform'
	from <internal:kernel>:91:in 'Kernel#tap'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/commands/server/server_command.rb:136:in 'Rails::Command::ServerCommand#perform'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/thor-1.4.0/lib/thor/command.rb:28:in 'Thor::Command#run'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/thor-1.4.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/command/base.rb:176:in 'Rails::Command::Base#invoke_command'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/thor-1.4.0/lib/thor.rb:538:in 'Thor.dispatch'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/command/base.rb:71:in 'Rails::Command::Base.perform'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/command.rb:65:in 'block in Rails::Command.invoke'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/command.rb:143:in 'Rails::Command.with_argv'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/command.rb:63:in 'Rails::Command.invoke'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/bundler/gems/rails-5724b1c7be45/railties/lib/rails/commands.rb:18:in '<main>'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from /Users/jasl/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bootsnap-1.19.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
	from bin/rails:5:in '<main>'
```

This patch fixed the issue

```
$ rails s
=> Booting Falcon v0.52.4
=> Rails 8.2.0.alpha application starting in development http://localhost:3000
=> Run `bin/rails server --help` for more startup options
 0.32s     info: Rails: Reading HTTP/1.1 requests for Async::HTTP::Protocol::HTTP1::Server. [ec=0x1f20] [pid=87284] [2025-12-07 20:54:26 +0800]
               | Processing by HomeController#index as HTML
 0.33s     info: Rails: Reading HTTP/1.1 requests for Async::HTTP::Protocol::HTTP1::Server. [ec=0x1f20] [pid=87284] [2025-12-07 20:54:26 +0800]
               |   Rendered home/index.html.erb within layouts/application (Duration: 0.1ms | GC: 0.0ms)
 0.33s     info: Rails: Reading HTTP/1.1 requests for Async::HTTP::Protocol::HTTP1::Server. [ec=0x1f20] [pid=87284] [2025-12-07 20:54:26 +0800]
               |   Rendered layout layouts/application.html.erb (Duration: 4.9ms | GC: 0.0ms)
 0.33s     info: process_action.action_controller: Reading HTTP/1.1 requests for Async::HTTP::Protocol::HTTP1::Server. [ec=0x1f20] [pid=87284] [2025-12-07 20:54:26 +0800]
               | {
               |   "controller": "HomeController",
               |   "action": "index",
               |   "format": "html",
               |   "method": "GET",
               |   "path": "/",
               |   "status": 200,
               |   "view_runtime": 7.593999996781349,
               |   "db_runtime": 0.0,
               |   "queries_count": 0,
               |   "cached_queries_count": 0,
               |   "source_address": "::1",
               |   "allocations": 17663,
               |   "duration": 16.033000007271767
               | }
 0.33s     info: Rails: Reading HTTP/1.1 requests for Async::HTTP::Protocol::HTTP1::Server. [ec=0x1f20] [pid=87284] [2025-12-07 20:54:26 +0800]
               | Completed 200 OK in 16ms (Views: 7.6ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.0ms)
               |
```

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
